### PR TITLE
Add proxy-fronted and service-mesh attested secure channel use cases

### DIFF
--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -386,23 +386,6 @@ This use case applies symmetrically to cases where the TLS server is the Atteste
 
 Relevant properties: Generic Integration Properties; Runtime Attestation; Privacy Preservation; Negotiation and Capability Discovery.
 
-## Service-Mesh Attestation
-
-Goal: Verify the runtime integrity of service-mesh components that mediate
-secure communication between application services.
-
-Use case: Microservices communicate through service-mesh proxies that perform
-TLS termination, routing, policy enforcement, and observability on behalf of
-application workloads.
-
-* Requirement: A peer must be able to obtain fresh, connection-bound Evidence
-  for the service-mesh component that terminates or mediates the secure channel,
-  so that mesh policy can distinguish an expected attested proxy from an
-  untrusted or misconfigured one.
-
-Relevant properties: Cryptographic Binding to Communication Channel; Runtime
-Attestation; Negotiation and Capability Discovery; Performance and Efficiency.
-
 ## Operation-Triggered Attestation for High-Impact Application Operations
 {: #sec-operation-triggered }
 

--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -339,49 +339,49 @@ network device's management interface.
 
 ## Proxy-Fronted Attested Secure Channels
 
-Goal: Support deployments in which an endpoint communicates with an attested 
-application, service, or confidential workload through one or more intermediaries 
-such as reverse proxies, API gateways, service-mesh components, load balancers, WAFs, 
+Goal: Support deployments in which an endpoint communicates with an attested
+application, service, or confidential workload through one or more intermediaries
+such as reverse proxies, API gateways, service-mesh components, load balancers, WAFs,
 or CDN edges.
 
-Use case: An endpoint connects to an application or confidential workload through an 
-intermediary that may terminate, inspect, relay, translate, or otherwise mediate the 
-secure channel for operational reasons such as routing, policy enforcement, 
-DDoS protection, observability, or protocol adaptation. The concern is not merely 
-whether attestation evidence can be conveyed over a secure channel, but whether the 
-resulting trust relationship corresponds to the component the relying party 
+Use case: An endpoint connects to an application or confidential workload through an
+intermediary that may terminate, inspect, relay, translate, or otherwise mediate the
+secure channel for operational reasons such as routing, policy enforcement,
+DDoS protection, observability, or protocol adaptation. The concern is not merely
+whether attestation evidence can be conveyed over a secure channel, but whether the
+resulting trust relationship corresponds to the component the relying party
 actually intends to appraise.
 
 Two distinct sub-cases should be considered:
 
-(a) The intermediary is itself the attested endpoint. The intermediary operates within a 
-TEE or otherwise provides attestable guarantees, and the relying party explicitly 
+(a) The intermediary is itself the attested endpoint. The intermediary operates within a
+TEE or otherwise provides attestable guarantees, and the relying party explicitly
 attests it as the service boundary. The origin behind the proxy need not be independently
-attested. This is mechanically equivalent to the base case of a TLS server attesting 
-to a client, but introduces a key management challenge: injecting a long-term WebPKI 
-identity key into the TEE runtime may be operationally or architecturally constrained, 
-affecting how the attested channel can be established and how tightly the credential 
+attested. This is mechanically equivalent to the base case of a TLS server attesting
+to a client, but introduces a key management challenge: injecting a long-term WebPKI
+identity key into the TEE runtime may be operationally or architecturally constrained,
+affecting how the attested channel can be established and how tightly the credential
 is bound to the attested workload.
 
 (b) The intermediary is a TLS-terminating component through which an endpoint seeks to
-appraise an origin workload. This sub-case presupposes that the intermediary is within 
-the same administrative domain as the origin and is accepted by the relying party as 
-trusted infrastructure; where it is not, the relying party should treat it as a trust 
-boundary and decline to extend attestation across it. Even so, the intermediary 
-represents a channel discontinuity: attestation evidence is bound to the proxy-terminated 
-session rather than to the origin directly, and establishing a meaningful binding requires 
+appraise an origin workload. This sub-case presupposes that the intermediary is within
+the same administrative domain as the origin and is accepted by the relying party as
+trusted infrastructure; where it is not, the relying party should treat it as a trust
+boundary and decline to extend attestation across it. Even so, the intermediary
+represents a channel discontinuity: attestation evidence is bound to the proxy-terminated
+session rather than to the origin directly, and establishing a meaningful binding requires
 application-layer mechanisms rather than reliance on the TLS channel to the proxy.
 
 This use case applies symmetrically to cases where the TLS server is the Attester, the TLS client is the Attester, or both endpoints mutually attest.
 
 * Requirement 1: Implementations should recognize both sub-cases as distinct trust topologies and avoid implicitly assuming only direct endpoint-to-endpoint paths, so that the choice of topology is explicit rather than an artifact of what the architecture happened to model.
-  
+
 * Requirement 2: For whichever sub-case applies, the architecture should make clear which components fall inside or outside the effective trust and confidentiality boundary, including where an intermediary terminates or mediates TLS, so that relying parties can make informed decisions rather than inherit unstated assumptions.
-  
+
 * Requirement 3: Where sub-case (b) is in scope, the architecture should consider whether nested or layered security associations are appropriate — an inner association providing end-to-end binding to the origin that is not terminated at the intermediary, and an outer association terminated at the intermediary — and should make clear that attestation binding to the origin is only meaningful if established over the inner association.
-  
+
 * Requirement 4: The architecture should identify what attestation guarantees continue to hold in each sub-case, including whether attestation is intended to apply to the origin endpoint alone, to the intermediary, or to some other appraised set of components.
-  
+
 * Requirement 5: The solution should support policy decisions that distinguish between direct attested channels, intermediary-as-attested-endpoint deployments, and proxy-traversal-to-attested-origin deployments. It should also be possible to detect when a topology changes — for instance when a previously direct attested channel is replaced by a TLS-terminating intermediary — so that such a change can be identified as a distinct condition rather than silently altering the trust relationship.
 
 Relevant properties: Generic Integration Properties; Runtime Attestation; Privacy Preservation; Negotiation and Capability Discovery.

--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -339,58 +339,52 @@ network device's management interface.
 
 ## Proxy-Fronted Attested Secure Channels
 
-Goal: Support deployments in which an endpoint communicates with an attested
-application, service, or confidential workload through one or more
-intermediaries such as reverse proxies, API gateways, service-mesh components,
-load balancers, WAFs, or CDN edges.
+Goal: Support deployments in which an endpoint communicates with an attested 
+application, service, or confidential workload through one or more intermediaries 
+such as reverse proxies, API gateways, service-mesh components, load balancers, WAFs, 
+or CDN edges.
 
-Use case: An endpoint connects to an application or confidential workload
-through an intermediary that may terminate, inspect, relay, translate, or
-otherwise mediate the secure channel for operational reasons such as routing,
-policy enforcement, DDoS protection, observability, or protocol adaptation.
+Use case: An endpoint connects to an application or confidential workload through an 
+intermediary that may terminate, inspect, relay, translate, or otherwise mediate the 
+secure channel for operational reasons such as routing, policy enforcement, 
+DDoS protection, observability, or protocol adaptation. The concern is not merely 
+whether attestation evidence can be conveyed over a secure channel, but whether the 
+resulting trust relationship corresponds to the component the relying party 
+actually intends to appraise.
 
 Two distinct sub-cases should be considered:
 
-(a) The intermediary is itself the attested endpoint. The intermediary operates
-within a TEE or otherwise provides attestable guarantees, and endpoints attest
-the intermediary directly. The origin behind the proxy need not be
-independently attested from the endpoint's perspective.
+(a) The intermediary is itself the attested endpoint. The intermediary operates within a 
+TEE or otherwise provides attestable guarantees, and the relying party explicitly 
+attests it as the service boundary. The origin behind the proxy need not be independently
+attested. This is mechanically equivalent to the base case of a TLS server attesting 
+to a client, but introduces a key management challenge: injecting a long-term WebPKI 
+identity key into the TEE runtime may be operationally or architecturally constrained, 
+affecting how the attested channel can be established and how tightly the credential 
+is bound to the attested workload.
 
-(b) The intermediary is a TLS-terminating third party through which an endpoint
-seeks to attest an origin workload. The endpoint does not control the
-intermediary, and the attested properties belong to the origin, not the proxy.
+(b) The intermediary is a TLS-terminating component through which an endpoint seeks to
+appraise an origin workload. This sub-case presupposes that the intermediary is within 
+the same administrative domain as the origin and is accepted by the relying party as 
+trusted infrastructure; where it is not, the relying party should treat it as a trust 
+boundary and decline to extend attestation across it. Even so, the intermediary 
+represents a channel discontinuity: attestation evidence is bound to the proxy-terminated 
+session rather than to the origin directly, and establishing a meaningful binding requires 
+application-layer mechanisms rather than reliance on the TLS channel to the proxy.
 
-This use case applies symmetrically to cases where the TLS server is the
-Attester, the TLS client is the Attester, or both endpoints mutually attest.
+This use case applies symmetrically to cases where the TLS server is the Attester, the TLS client is the Attester, or both endpoints mutually attest.
 
-* Requirement 1: The architecture must address both sub-cases when permitted by
-implementation choice and local policy, rather than assuming only direct
-endpoint-to-endpoint paths implicitly.
+* Requirement 1: Implementations should recognize both sub-cases as distinct trust topologies and avoid implicitly assuming only direct endpoint-to-endpoint paths, so that the choice of topology is explicit rather than an artifact of what the architecture happened to model.
+  
+* Requirement 2: For whichever sub-case applies, the architecture should make clear which components fall inside or outside the effective trust and confidentiality boundary, including where an intermediary terminates or mediates TLS, so that relying parties can make informed decisions rather than inherit unstated assumptions.
+  
+* Requirement 3: Where sub-case (b) is in scope, the architecture should consider whether nested or layered security associations are appropriate — an inner association providing end-to-end binding to the origin that is not terminated at the intermediary, and an outer association terminated at the intermediary — and should make clear that attestation binding to the origin is only meaningful if established over the inner association.
+  
+* Requirement 4: The architecture should identify what attestation guarantees continue to hold in each sub-case, including whether attestation is intended to apply to the origin endpoint alone, to the intermediary, or to some other appraised set of components.
+  
+* Requirement 5: The solution should support policy decisions that distinguish between direct attested channels, intermediary-as-attested-endpoint deployments, and proxy-traversal-to-attested-origin deployments. It should also be possible to detect when a topology changes — for instance when a previously direct attested channel is replaced by a TLS-terminating intermediary — so that such a change can be identified as a distinct condition rather than silently altering the trust relationship.
 
-* Requirement 2: The architecture must make explicit which components are
-inside or outside the effective trust and confidentiality boundary for each
-sub-case, including cases where an intermediary terminates or mediates TLS.
-
-* Requirement 3: For sub-case (b), the architecture must specify how an
-endpoint can establish a channel identity that is cryptographically bound to
-the attested origin endpoint even when connection establishment traverses a
-TLS-terminating intermediary, so that remote attestation mechanisms can operate
-on a meaningful channel binding to the origin rather than on a proxy-terminated
-session.
-
-* Requirement 4: The architecture should make clear what attestation guarantees
-continue to hold in each sub-case, including whether attestation is intended to
-apply to the origin endpoint alone, to the intermediary, or to some other
-appraised set of components.
-
-* Requirement 5: The solution should support policy decisions that distinguish
-between direct attested channels, intermediary-as-attested-endpoint
-deployments, and proxy-traversal-to-attested-origin deployments, so that
-relying parties can determine whether a given deployment topology is acceptable
-for their use case.
-
-Relevant properties: Generic Integration Properties; Runtime Attestation;
-Privacy Preservation; Negotiation and Capability Discovery.
+Relevant properties: Generic Integration Properties; Runtime Attestation; Privacy Preservation; Negotiation and Capability Discovery.
 
 ## Service-Mesh Attestation
 

--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -337,6 +337,78 @@ network device's management interface.
   management endpoint on the network device to ensure they are not connecting to
   a compromised interface that could steal credentials or manipulate the device.
 
+## Proxy-Fronted Attested Secure Channels
+
+Goal: Support deployments in which an endpoint communicates with an attested
+application, service, or confidential workload through one or more
+intermediaries such as reverse proxies, API gateways, service-mesh components,
+load balancers, WAFs, or CDN edges.
+
+Use case: An endpoint connects to an application or confidential workload
+through an intermediary that may terminate, inspect, relay, translate, or
+otherwise mediate the secure channel for operational reasons such as routing,
+policy enforcement, DDoS protection, observability, or protocol adaptation.
+
+Two distinct sub-cases should be considered:
+
+(a) The intermediary is itself the attested endpoint. The intermediary operates
+within a TEE or otherwise provides attestable guarantees, and endpoints attest
+the intermediary directly. The origin behind the proxy need not be
+independently attested from the endpoint's perspective.
+
+(b) The intermediary is a TLS-terminating third party through which an endpoint
+seeks to attest an origin workload. The endpoint does not control the
+intermediary, and the attested properties belong to the origin, not the proxy.
+
+This use case applies symmetrically to cases where the TLS server is the
+Attester, the TLS client is the Attester, or both endpoints mutually attest.
+
+* Requirement 1: The architecture must address both sub-cases when permitted by
+implementation choice and local policy, rather than assuming only direct
+endpoint-to-endpoint paths implicitly.
+
+* Requirement 2: The architecture must make explicit which components are
+inside or outside the effective trust and confidentiality boundary for each
+sub-case, including cases where an intermediary terminates or mediates TLS.
+
+* Requirement 3: For sub-case (b), the architecture must specify how an
+endpoint can establish a channel identity that is cryptographically bound to
+the attested origin endpoint even when connection establishment traverses a
+TLS-terminating intermediary, so that remote attestation mechanisms can operate
+on a meaningful channel binding to the origin rather than on a proxy-terminated
+session.
+
+* Requirement 4: The architecture should make clear what attestation guarantees
+continue to hold in each sub-case, including whether attestation is intended to
+apply to the origin endpoint alone, to the intermediary, or to some other
+appraised set of components.
+
+* Requirement 5: The solution should support policy decisions that distinguish
+between direct attested channels, intermediary-as-attested-endpoint
+deployments, and proxy-traversal-to-attested-origin deployments, so that
+relying parties can determine whether a given deployment topology is acceptable
+for their use case.
+
+Relevant properties: Generic Integration Properties; Runtime Attestation;
+Privacy Preservation; Negotiation and Capability Discovery.
+
+## Service-Mesh Attestation
+
+Goal: Verify the runtime integrity of service-mesh components that mediate
+secure communication between application services.
+
+Use case: Microservices communicate through service-mesh proxies that perform
+TLS termination, routing, policy enforcement, and observability on behalf of
+application workloads.
+
+* Requirement: A peer must be able to obtain fresh, connection-bound Evidence
+  for the service-mesh component that terminates or mediates the secure channel,
+  so that mesh policy can distinguish an expected attested proxy from an
+  untrusted or misconfigured one.
+
+Relevant properties: Cryptographic Binding to Communication Channel; Runtime
+Attestation; Negotiation and Capability Discovery; Performance and Efficiency.
+
 ## Operation-Triggered Attestation for High-Impact Application Operations
 {: #sec-operation-triggered }
 


### PR DESCRIPTION
* Added proxy-fronted attested secure channel use case
* Added service-mesh attestation use case
* Covered TLS-terminating intermediaries: reverse proxies, API gateways, service meshes, WAFs, load balancers, and CDN edges
* Distinguished intermediary-as-attested-endpoint from proxy-traversal-to-attested-origin
* Generalized proxy use case from client-origin to endpoint-origin
* Covered server attestation, client attestation, and mutual attestation
* Added requirements for explicit trust and confidentiality boundaries
* Added requirements for meaningful channel binding when TLS is terminated by an intermediary
* Added policy distinction between direct attested channels, attested intermediaries, and proxy-traversal deployments