### PR TITLE
Add framing subsection on diverse trust boundaries

### DIFF
--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -226,6 +226,10 @@ The solution supports using RA in conjunction with traditional PKI-based
 authentication (e.g., X.509 certificates). This provides two independent pillars
 of trust: endpoint trustworthiness (from RA) and identity (from PKI).
 
+## Navigating Diverse Trust Boundaries
+
+Remote attestation over secure channels seeks to establish the highest-assurance connections possible by ensuring that trust is derived from verifiable evidence rather than assumed from the underlying network or infrastructure. This raises the deployment complexity above that of standard secure-channel technologies, especially when a network path may be traversed by unavoidable intermediaries (such as TLS-terminating reverse proxies or API gateways) that solutions will need to anticipate. To manage this, solutions should holistically consider the specific deployment context, the nature of the peer's PKI-based identity, the scope of the attested component, and the role and reachability of the Verifier in the chosen attestation model.
+
 ## Runtime Attestation
 
 Evidence collected at certificate issuance or during the initial secure channel establishment reflects only the Target Environment’s state at that moment. It cannot guarantee that the Target Environment remains trustworthy for the lifetime of the certificate or even for the duration of the secure connection (e.g., the (D)TLS connection). As a result, such static Evidence is insufficient in environments where the Target Environment may change state after the connection is established and the connection is long-lived.

--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -228,7 +228,7 @@ of trust: endpoint trustworthiness (from RA) and identity (from PKI).
 
 ## Navigating Diverse Trust Boundaries
 
-Remote attestation over secure channels seeks to establish the highest-assurance connections possible by ensuring that trust is derived from verifiable evidence rather than assumed from the underlying network or infrastructure. This raises the deployment complexity above that of standard secure-channel technologies, especially when a network path may traverse unavoidable intermediaries (such as TLS-terminating reverse proxies or API gateways) that solutions will need to anticipate. To manage this, solutions should holistically consider the specific deployment context, the nature of the peer's PKI-based identity, the scope of the attested component, and the role and reachability of the Verifier in the chosen attestation model.
+Remote attestation over secure channels seeks to establish the highest-assurance connections possible by ensuring that trust is derived from verifiable evidence rather than assumed from the underlying network or infrastructure. This raises the deployment complexity above that of standard secure-channel technologies, especially when a network path may traverse unavoidable intermediaries (such as TLS-terminating reverse proxies or API gateways) that solutions will need to anticipate. To manage this, solutions should holistically consider the specific deployment context, the nature of the peer's PKI-based identity, the scope of the attested component, and the role and reachability of the Attester in the chosen attestation model.
 
 ## Runtime Attestation
 

--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -228,7 +228,7 @@ of trust: endpoint trustworthiness (from RA) and identity (from PKI).
 
 ## Navigating Diverse Trust Boundaries
 
-Remote attestation over secure channels seeks to establish the highest-assurance connections possible by ensuring that trust is derived from verifiable evidence rather than assumed from the underlying network or infrastructure. This raises the deployment complexity above that of standard secure-channel technologies, especially when a network path may be traversed by unavoidable intermediaries (such as TLS-terminating reverse proxies or API gateways) that solutions will need to anticipate. To manage this, solutions should holistically consider the specific deployment context, the nature of the peer's PKI-based identity, the scope of the attested component, and the role and reachability of the Verifier in the chosen attestation model.
+Remote attestation over secure channels seeks to establish the highest-assurance connections possible by ensuring that trust is derived from verifiable evidence rather than assumed from the underlying network or infrastructure. This raises the deployment complexity above that of standard secure-channel technologies, especially when a network path may traverse unavoidable intermediaries (such as TLS-terminating reverse proxies or API gateways) that solutions will need to anticipate. To manage this, solutions should holistically consider the specific deployment context, the nature of the peer's PKI-based identity, the scope of the attested component, and the role and reachability of the Verifier in the chosen attestation model.
 
 ## Runtime Attestation
 


### PR DESCRIPTION
Adds a short introductory paragraph contextualising the deployment complexity that arises when RA is composed with secure channels, particularly in the presence of TLS-terminating intermediaries that are authorised and cooperative but structurally indistinguishable from adversarial positions at the protocol level.

Motivates the proxy-fronted deployment discussion introduced in PR #48 and grounds the Verifier reachability discussion in the attestation model flexibility property.