### PR TITLE
Add Web PKI identity injection use case for ephemeral containers

### DIFF
--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -416,6 +416,25 @@ certificate is enrolled. This model does not provide guarantees about the
 continued state of the module at connection establishment or during the lifetime of
 the TLS connection.
 
+## Web PKI Identity Injection for Ephemeral Containers
+
+Goal: Provide per-session freshness for externally provisioned identity 
+credentials by binding the transport layer session material directly to the 
+target execution environment.
+
+Use case: An operator runs short-lived container workloads inside 
+hardware-isolated Trusted Execution Environments (TEEs) and requires them
+to authenticate their secure channels using standard certificates that chain
+to a public Web PKI. Because these container workloads are highly temporary,
+obtaining a unique, CA-backed certificate dynamically for every single instance
+lifecycle introduces prohibitive deployment latency. Instead, the identity
+certificate and its corresponding private key are pre-obtained by an external
+utility operating in the cluster orchestration plane (such as a certificate
+manager) and loaded directly into the virtual machine upon instantiation.
+
+*  Requirement: Provide per-session freshness with cryptographic binding to 
+   communication channel.
+
 ## Platform-to-platform communication
 
 Goal: Allow platforms to establish a trustworthy secure channel with each other.

--- a/draft-mihalcea-seat-use-cases.md
+++ b/draft-mihalcea-seat-use-cases.md
@@ -418,11 +418,11 @@ the TLS connection.
 
 ## Web PKI Identity Injection for Ephemeral Containers
 
-Goal: Provide per-session freshness for externally provisioned identity 
-credentials by binding the transport layer session material directly to the 
+Goal: Provide per-session freshness for externally provisioned identity
+credentials by binding the transport layer session material directly to the
 target execution environment.
 
-Use case: An operator runs short-lived container workloads inside 
+Use case: An operator runs short-lived container workloads inside
 hardware-isolated Trusted Execution Environments (TEEs) and requires them
 to authenticate their secure channels using standard certificates that chain
 to a public Web PKI. Because these container workloads are highly temporary,
@@ -432,7 +432,7 @@ certificate and its corresponding private key are pre-obtained by an external
 utility operating in the cluster orchestration plane (such as a certificate
 manager) and loaded directly into the virtual machine upon instantiation.
 
-*  Requirement: Provide per-session freshness with cryptographic binding to 
+*  Requirement: Provide per-session freshness with cryptographic binding to
    communication channel.
 
 ## Platform-to-platform communication


### PR DESCRIPTION
Adds a new use case based on [Markus Rudy's feedback ](https://mailarchive.ietf.org/arch/msg/seat/GcrnRi81zcpZUOG_213U2ongrnc/)regarding short-lived container workloads in TEEs.

---

* Documents ephemeral container workloads authenticating via public Web PKI.

* Addresses the prohibitive latency of fetching certificates dynamically for temporary instances by supporting external provisioning (e.g., via cert manager).

*  Mandates per-session freshness and cryptographic binding to the communication channel